### PR TITLE
Fix sum return type for income projections

### DIFF
--- a/src/main/java/com/aurfebre/household/repository/IncomeProjectionRepository.java
+++ b/src/main/java/com/aurfebre/household/repository/IncomeProjectionRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,7 +23,7 @@ public interface IncomeProjectionRepository extends JpaRepository<IncomeProjecti
 
     @Query("SELECT SUM(ip.projectedAnnualIncome) FROM IncomeProjection ip " +
            "WHERE ip.userId = :userId AND ip.year = :year AND ip.isActive = true")
-    Optional<Double> sumProjectedIncomeByUserIdAndYear(@Param("userId") Long userId, @Param("year") Integer year);
+    Optional<BigDecimal> sumProjectedIncomeByUserIdAndYear(@Param("userId") Long userId, @Param("year") Integer year);
 
     @Query("SELECT ip FROM IncomeProjection ip " +
            "WHERE ip.userId = :userId AND ip.year >= :startYear AND ip.year <= :endYear AND ip.isActive = true " +

--- a/src/main/java/com/aurfebre/household/service/IncomeProjectionService.java
+++ b/src/main/java/com/aurfebre/household/service/IncomeProjectionService.java
@@ -88,7 +88,6 @@ public class IncomeProjectionService {
         }
 
         return incomeProjectionRepository.sumProjectedIncomeByUserIdAndYear(userId, year)
-                .map(BigDecimal::valueOf)
                 .orElse(BigDecimal.ZERO);
     }
 

--- a/src/test/java/com/aurfebre/household/service/IncomeProjectionServiceTest.java
+++ b/src/test/java/com/aurfebre/household/service/IncomeProjectionServiceTest.java
@@ -1,0 +1,76 @@
+package com.aurfebre.household.service;
+
+import com.aurfebre.household.dto.IncomeProjectionRequest;
+import com.aurfebre.household.dto.IncomeProjectionResponse;
+import com.aurfebre.household.domain.IncomeProjection;
+import com.aurfebre.household.repository.IncomeProjectionRepository;
+import com.aurfebre.household.security.CustomUserPrincipal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class IncomeProjectionServiceTest {
+
+    @Mock
+    private IncomeProjectionRepository incomeProjectionRepository;
+
+    @InjectMocks
+    private IncomeProjectionService incomeProjectionService;
+
+    @BeforeEach
+    void setUp() {
+        CustomUserPrincipal principal = new CustomUserPrincipal(
+                1L,
+                "test@example.com",
+                "",
+                "Test User",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getTotalProjectedIncomeForYear_WhenDataExists_ShouldReturnTotal() {
+        BigDecimal total = new BigDecimal("5000000");
+        when(incomeProjectionRepository.sumProjectedIncomeByUserIdAndYear(1L, 2025))
+                .thenReturn(Optional.of(total));
+
+        BigDecimal result = incomeProjectionService.getTotalProjectedIncomeForYear(2025);
+
+        assertThat(result).isEqualByComparingTo(total);
+        verify(incomeProjectionRepository).sumProjectedIncomeByUserIdAndYear(1L, 2025);
+    }
+
+    @Test
+    void getTotalProjectedIncomeForYear_WhenNoData_ShouldReturnZero() {
+        when(incomeProjectionRepository.sumProjectedIncomeByUserIdAndYear(1L, 2025))
+                .thenReturn(Optional.empty());
+
+        BigDecimal result = incomeProjectionService.getTotalProjectedIncomeForYear(2025);
+
+        assertThat(result).isEqualByComparingTo(BigDecimal.ZERO);
+        verify(incomeProjectionRepository).sumProjectedIncomeByUserIdAndYear(1L, 2025);
+    }
+}


### PR DESCRIPTION
## Summary
- fix repository sum return type to `BigDecimal`
- adjust service to handle new `BigDecimal` type
- add unit tests for `IncomeProjectionService`

## Testing
- `./gradlew test --no-daemon --offline` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687e3e3c9a10832e9256af2b43458d53