### PR TITLE
feat: add financial goal service and controller

### DIFF
--- a/src/main/java/com/aurfebre/household/api/FinancialGoalController.java
+++ b/src/main/java/com/aurfebre/household/api/FinancialGoalController.java
@@ -1,0 +1,86 @@
+package com.aurfebre.household.api;
+
+import com.aurfebre.household.domain.FinancialGoal;
+import com.aurfebre.household.service.FinancialGoalService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/financial-goals")
+public class FinancialGoalController {
+
+    private final FinancialGoalService financialGoalService;
+
+    public FinancialGoalController(FinancialGoalService financialGoalService) {
+        this.financialGoalService = financialGoalService;
+    }
+
+    @GetMapping("/user/{userId}")
+    public List<FinancialGoal> getGoalsByUserId(@PathVariable Long userId) {
+        return financialGoalService.getGoalsByUserId(userId);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<FinancialGoal> getGoalById(@PathVariable Long id) {
+        return financialGoalService.getGoalById(id)
+            .map(ResponseEntity::ok)
+            .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public FinancialGoal createGoal(@RequestBody FinancialGoal goal) {
+        return financialGoalService.createGoal(goal);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<FinancialGoal> updateGoal(@PathVariable Long id, @RequestBody FinancialGoal goalDetails) {
+        try {
+            FinancialGoal updated = financialGoalService.updateGoal(id, goalDetails);
+            return ResponseEntity.ok(updated);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteGoal(@PathVariable Long id) {
+        try {
+            financialGoalService.deleteGoal(id);
+            return ResponseEntity.noContent().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping("/{id}/hard")
+    public ResponseEntity<?> hardDeleteGoal(@PathVariable Long id) {
+        try {
+            financialGoalService.hardDeleteGoal(id);
+            return ResponseEntity.noContent().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @GetMapping("/{id}/progress")
+    public ResponseEntity<BigDecimal> getProgress(@PathVariable Long id) {
+        try {
+            BigDecimal progress = financialGoalService.getProgress(id);
+            return ResponseEntity.ok(progress);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PostMapping("/apply-contribution")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public void applyMonthlyContribution() {
+        financialGoalService.applyMonthlyContribution();
+    }
+}
+

--- a/src/main/java/com/aurfebre/household/service/FinancialGoalService.java
+++ b/src/main/java/com/aurfebre/household/service/FinancialGoalService.java
@@ -1,0 +1,109 @@
+package com.aurfebre.household.service;
+
+import com.aurfebre.household.domain.FinancialGoal;
+import com.aurfebre.household.repository.FinancialGoalRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class FinancialGoalService {
+
+    private final FinancialGoalRepository financialGoalRepository;
+
+    public FinancialGoalService(FinancialGoalRepository financialGoalRepository) {
+        this.financialGoalRepository = financialGoalRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<FinancialGoal> getGoalsByUserId(Long userId) {
+        return financialGoalRepository.findByUserIdAndIsActiveTrueOrderByPriorityAsc(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<FinancialGoal> getGoalById(Long id) {
+        return financialGoalRepository.findById(id);
+    }
+
+    public FinancialGoal createGoal(FinancialGoal goal) {
+        validateGoal(goal);
+        if (goal.getPriority() != null &&
+            financialGoalRepository.existsByUserIdAndPriorityAndIsActiveTrue(goal.getUserId(), goal.getPriority())) {
+            throw new IllegalArgumentException("Active goal already exists with this priority");
+        }
+        return financialGoalRepository.save(goal);
+    }
+
+    public FinancialGoal updateGoal(Long id, FinancialGoal goalDetails) {
+        FinancialGoal goal = financialGoalRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("Goal not found with id: " + id));
+
+        validateGoal(goalDetails);
+
+        if (goalDetails.getPriority() != null && !goalDetails.getPriority().equals(goal.getPriority()) &&
+            financialGoalRepository.existsByUserIdAndPriorityAndIsActiveTrue(goal.getUserId(), goalDetails.getPriority())) {
+            throw new IllegalArgumentException("Active goal already exists with this priority");
+        }
+
+        goal.setGoalType(goalDetails.getGoalType());
+        goal.setName(goalDetails.getName());
+        goal.setTargetAmount(goalDetails.getTargetAmount());
+        goal.setCurrentAmount(goalDetails.getCurrentAmount());
+        goal.setTargetDate(goalDetails.getTargetDate());
+        goal.setMonthlyContribution(goalDetails.getMonthlyContribution());
+        goal.setPriority(goalDetails.getPriority());
+
+        return financialGoalRepository.save(goal);
+    }
+
+    public void deleteGoal(Long id) {
+        FinancialGoal goal = financialGoalRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("Goal not found with id: " + id));
+        goal.setIsActive(false);
+        financialGoalRepository.save(goal);
+    }
+
+    public void hardDeleteGoal(Long id) {
+        if (!financialGoalRepository.existsById(id)) {
+            throw new IllegalArgumentException("Goal not found with id: " + id);
+        }
+        financialGoalRepository.deleteById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public BigDecimal getProgress(Long goalId) {
+        FinancialGoal goal = financialGoalRepository.findById(goalId)
+            .orElseThrow(() -> new IllegalArgumentException("Goal not found with id: " + goalId));
+        return calculateProgress(goal);
+    }
+
+    private BigDecimal calculateProgress(FinancialGoal goal) {
+        if (goal.getTargetAmount() == null || goal.getTargetAmount().compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO;
+        }
+        BigDecimal progress = goal.getCurrentAmount().divide(goal.getTargetAmount(), 4, RoundingMode.HALF_UP);
+        return progress.multiply(BigDecimal.valueOf(100));
+    }
+
+    public void applyMonthlyContribution() {
+        List<FinancialGoal> goals = financialGoalRepository.findAll();
+        for (FinancialGoal goal : goals) {
+            if (Boolean.TRUE.equals(goal.getIsActive()) && goal.getMonthlyContribution() != null) {
+                goal.setCurrentAmount(goal.getCurrentAmount().add(goal.getMonthlyContribution()));
+            }
+        }
+        financialGoalRepository.saveAll(goals);
+    }
+
+    private void validateGoal(FinancialGoal goal) {
+        if (goal.getTargetAmount() == null || goal.getTargetAmount().compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Target amount must be greater than zero");
+        }
+    }
+}
+

--- a/src/test/java/com/aurfebre/household/service/FinancialGoalServiceTest.java
+++ b/src/test/java/com/aurfebre/household/service/FinancialGoalServiceTest.java
@@ -1,0 +1,110 @@
+package com.aurfebre.household.service;
+
+import com.aurfebre.household.domain.FinancialGoal;
+import com.aurfebre.household.domain.enums.GoalType;
+import com.aurfebre.household.repository.FinancialGoalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FinancialGoalServiceTest {
+
+    @Mock
+    private FinancialGoalRepository financialGoalRepository;
+
+    @InjectMocks
+    private FinancialGoalService financialGoalService;
+
+    private FinancialGoal testGoal;
+
+    @BeforeEach
+    void setUp() {
+        testGoal = new FinancialGoal(1L, GoalType.SAVING, "Emergency Fund",
+            new BigDecimal("10000"), LocalDate.of(2025, 12, 31), 1);
+        testGoal.setId(1L);
+    }
+
+    @Test
+    void createGoal_ShouldSaveGoal() {
+        when(financialGoalRepository.existsByUserIdAndPriorityAndIsActiveTrue(1L, 1)).thenReturn(false);
+        when(financialGoalRepository.save(any(FinancialGoal.class))).thenReturn(testGoal);
+
+        FinancialGoal result = financialGoalService.createGoal(testGoal);
+
+        assertThat(result).isEqualTo(testGoal);
+        verify(financialGoalRepository).save(testGoal);
+    }
+
+    @Test
+    void updateGoal_ShouldUpdateGoal() {
+        FinancialGoal updatedDetails = new FinancialGoal(1L, GoalType.SAVING, "Vacation",
+            new BigDecimal("15000"), LocalDate.of(2026, 6, 30), 2);
+        updatedDetails.setCurrentAmount(new BigDecimal("5000"));
+
+        when(financialGoalRepository.findById(1L)).thenReturn(Optional.of(testGoal));
+        when(financialGoalRepository.existsByUserIdAndPriorityAndIsActiveTrue(1L, 2)).thenReturn(false);
+        when(financialGoalRepository.save(any(FinancialGoal.class))).thenReturn(updatedDetails);
+
+        FinancialGoal result = financialGoalService.updateGoal(1L, updatedDetails);
+
+        assertThat(result.getName()).isEqualTo("Vacation");
+        assertThat(result.getPriority()).isEqualTo(2);
+        verify(financialGoalRepository).save(testGoal);
+    }
+
+    @Test
+    void deleteGoal_ShouldDeactivateGoal() {
+        when(financialGoalRepository.findById(1L)).thenReturn(Optional.of(testGoal));
+
+        financialGoalService.deleteGoal(1L);
+
+        assertThat(testGoal.getIsActive()).isFalse();
+        verify(financialGoalRepository).save(testGoal);
+    }
+
+    @Test
+    void hardDeleteGoal_ShouldRemoveGoal() {
+        when(financialGoalRepository.existsById(1L)).thenReturn(true);
+
+        financialGoalService.hardDeleteGoal(1L);
+
+        verify(financialGoalRepository).deleteById(1L);
+    }
+
+    @Test
+    void getProgress_ShouldReturnCorrectPercentage() {
+        testGoal.setCurrentAmount(new BigDecimal("2000"));
+        when(financialGoalRepository.findById(1L)).thenReturn(Optional.of(testGoal));
+
+        BigDecimal progress = financialGoalService.getProgress(1L);
+
+        assertThat(progress).isEqualTo(new BigDecimal("20.0000"));
+    }
+
+    @Test
+    void applyMonthlyContribution_ShouldIncreaseCurrentAmount() {
+        testGoal.setMonthlyContribution(new BigDecimal("500"));
+        List<FinancialGoal> goals = Arrays.asList(testGoal);
+        when(financialGoalRepository.findAll()).thenReturn(goals);
+
+        financialGoalService.applyMonthlyContribution();
+
+        assertThat(testGoal.getCurrentAmount()).isEqualByComparingTo(new BigDecimal("500"));
+        verify(financialGoalRepository).saveAll(goals);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement FinancialGoalService with CRUD, progress calculation, and monthly contribution updates
- expose REST endpoints for managing goals and retrieving progress
- add unit tests for goal operations and progress updates

## Testing
- `gradle test --offline` *(fails: Plugin [id: 'org.springframework.boot', version: '3.5.3'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890b7e9121c832eb7b5acaee0933951