### PR TITLE
feat: support custom budget cycles

### DIFF
--- a/src/main/java/com/aurfebre/household/api/MonthlyExpenseController.java
+++ b/src/main/java/com/aurfebre/household/api/MonthlyExpenseController.java
@@ -4,6 +4,7 @@ import com.aurfebre.household.domain.LedgerEntry;
 import com.aurfebre.household.dto.MonthlyExpenseComparison;
 import com.aurfebre.household.dto.MonthlyExpenseSummary;
 import com.aurfebre.household.service.MonthlyExpenseService;
+import com.aurfebre.household.service.UserBudgetSettingsService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,9 +16,12 @@ import java.util.List;
 public class MonthlyExpenseController {
 
     private final MonthlyExpenseService monthlyExpenseService;
+    private final UserBudgetSettingsService userBudgetSettingsService;
 
-    public MonthlyExpenseController(MonthlyExpenseService monthlyExpenseService) {
+    public MonthlyExpenseController(MonthlyExpenseService monthlyExpenseService,
+                                    UserBudgetSettingsService userBudgetSettingsService) {
         this.monthlyExpenseService = monthlyExpenseService;
+        this.userBudgetSettingsService = userBudgetSettingsService;
     }
 
     @GetMapping("/user/{userId}")
@@ -25,7 +29,8 @@ public class MonthlyExpenseController {
             @PathVariable Long userId,
             @RequestParam YearMonth yearMonth) {
         
-        List<LedgerEntry> expenses = monthlyExpenseService.getMonthlyExpenses(userId, yearMonth);
+        int monthStartDay = userBudgetSettingsService.getSettings(userId).getMonthStartDay();
+        List<LedgerEntry> expenses = monthlyExpenseService.getMonthlyExpenses(userId, yearMonth, monthStartDay);
         return ResponseEntity.ok(expenses);
     }
 
@@ -34,7 +39,8 @@ public class MonthlyExpenseController {
             @PathVariable Long userId,
             @RequestParam YearMonth yearMonth) {
         
-        MonthlyExpenseSummary summary = monthlyExpenseService.getMonthlyExpensesSummary(userId, yearMonth);
+        int monthStartDay = userBudgetSettingsService.getSettings(userId).getMonthStartDay();
+        MonthlyExpenseSummary summary = monthlyExpenseService.getMonthlyExpensesSummary(userId, yearMonth, monthStartDay);
         return ResponseEntity.ok(summary);
     }
 
@@ -43,7 +49,8 @@ public class MonthlyExpenseController {
             @PathVariable Long userId,
             @RequestParam YearMonth yearMonth) {
         
-        MonthlyExpenseComparison comparison = monthlyExpenseService.getMonthlyComparison(userId, yearMonth);
+        int monthStartDay = userBudgetSettingsService.getSettings(userId).getMonthStartDay();
+        MonthlyExpenseComparison comparison = monthlyExpenseService.getMonthlyComparison(userId, yearMonth, monthStartDay);
         return ResponseEntity.ok(comparison);
     }
 }

--- a/src/main/java/com/aurfebre/household/domain/UserBudgetSettings.java
+++ b/src/main/java/com/aurfebre/household/domain/UserBudgetSettings.java
@@ -1,0 +1,76 @@
+package com.aurfebre.household.domain;
+
+import com.aurfebre.household.domain.enums.CycleType;
+import jakarta.persistence.*;
+import java.time.DayOfWeek;
+
+@Entity
+@Table(name = "user_budget_settings")
+public class UserBudgetSettings {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Integer monthStartDay;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CycleType cycleType;
+
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek weekStartDay;
+
+    public UserBudgetSettings() {}
+
+    public UserBudgetSettings(Long userId, Integer monthStartDay, CycleType cycleType, DayOfWeek weekStartDay) {
+        this.userId = userId;
+        this.monthStartDay = monthStartDay;
+        this.cycleType = cycleType;
+        this.weekStartDay = weekStartDay;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Integer getMonthStartDay() {
+        return monthStartDay;
+    }
+
+    public void setMonthStartDay(Integer monthStartDay) {
+        this.monthStartDay = monthStartDay;
+    }
+
+    public CycleType getCycleType() {
+        return cycleType;
+    }
+
+    public void setCycleType(CycleType cycleType) {
+        this.cycleType = cycleType;
+    }
+
+    public DayOfWeek getWeekStartDay() {
+        return weekStartDay;
+    }
+
+    public void setWeekStartDay(DayOfWeek weekStartDay) {
+        this.weekStartDay = weekStartDay;
+    }
+}

--- a/src/main/java/com/aurfebre/household/domain/enums/CycleType.java
+++ b/src/main/java/com/aurfebre/household/domain/enums/CycleType.java
@@ -1,0 +1,6 @@
+package com.aurfebre.household.domain.enums;
+
+public enum CycleType {
+    MONTHLY,
+    WEEKLY
+}

--- a/src/main/java/com/aurfebre/household/repository/UserBudgetSettingsRepository.java
+++ b/src/main/java/com/aurfebre/household/repository/UserBudgetSettingsRepository.java
@@ -1,0 +1,12 @@
+package com.aurfebre.household.repository;
+
+import com.aurfebre.household.domain.UserBudgetSettings;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserBudgetSettingsRepository extends JpaRepository<UserBudgetSettings, Long> {
+    Optional<UserBudgetSettings> findByUserId(Long userId);
+}

--- a/src/main/java/com/aurfebre/household/service/FinancialGoalService.java
+++ b/src/main/java/com/aurfebre/household/service/FinancialGoalService.java
@@ -1,0 +1,66 @@
+package com.aurfebre.household.service;
+
+import com.aurfebre.household.domain.FinancialGoal;
+import com.aurfebre.household.repository.FinancialGoalRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class FinancialGoalService {
+
+    private final FinancialGoalRepository financialGoalRepository;
+    private final UserBudgetSettingsService userBudgetSettingsService;
+
+    public FinancialGoalService(FinancialGoalRepository financialGoalRepository,
+                                UserBudgetSettingsService userBudgetSettingsService) {
+        this.financialGoalRepository = financialGoalRepository;
+        this.userBudgetSettingsService = userBudgetSettingsService;
+    }
+
+    @Transactional(readOnly = true)
+    public List<FinancialGoal> getGoalsByUserId(Long userId) {
+        return financialGoalRepository.findByUserIdAndIsActiveTrueOrderByPriorityAsc(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FinancialGoal> getGoalsDueByMonth(Long userId, YearMonth yearMonth) {
+        int monthStartDay = userBudgetSettingsService.getSettings(userId).getMonthStartDay();
+        LocalDate start = yearMonth.atDay(monthStartDay);
+        LocalDate end = start.plusMonths(1).minusDays(1);
+        return financialGoalRepository.findGoalsDueByDate(userId, end);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<FinancialGoal> getGoalById(Long id) {
+        return financialGoalRepository.findById(id);
+    }
+
+    public FinancialGoal createGoal(FinancialGoal goal) {
+        return financialGoalRepository.save(goal);
+    }
+
+    public FinancialGoal updateGoal(Long id, FinancialGoal goalDetails) {
+        FinancialGoal goal = financialGoalRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("FinancialGoal not found with id: " + id));
+
+        goal.setGoalType(goalDetails.getGoalType());
+        goal.setName(goalDetails.getName());
+        goal.setTargetAmount(goalDetails.getTargetAmount());
+        goal.setCurrentAmount(goalDetails.getCurrentAmount());
+        goal.setTargetDate(goalDetails.getTargetDate());
+        goal.setMonthlyContribution(goalDetails.getMonthlyContribution());
+        goal.setPriority(goalDetails.getPriority());
+
+        return financialGoalRepository.save(goal);
+    }
+
+    public void deleteGoal(Long id) {
+        financialGoalRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/aurfebre/household/service/MonthlyExpenseService.java
+++ b/src/main/java/com/aurfebre/household/service/MonthlyExpenseService.java
@@ -25,15 +25,23 @@ public class MonthlyExpenseService {
     }
 
     public List<LedgerEntry> getMonthlyExpenses(Long userId, YearMonth yearMonth) {
-        LocalDate startDate = yearMonth.atDay(1);
-        LocalDate endDate = yearMonth.atEndOfMonth();
-        
+        return getMonthlyExpenses(userId, yearMonth, 1);
+    }
+
+    public List<LedgerEntry> getMonthlyExpenses(Long userId, YearMonth yearMonth, int monthStartDay) {
+        LocalDate startDate = yearMonth.atDay(monthStartDay);
+        LocalDate endDate = startDate.plusMonths(1).minusDays(1);
+
         return ledgerEntryRepository.findByUserIdAndEntryTypeAndDateBetweenOrderByDateDesc(
             userId, EntryType.EXPENSE, startDate, endDate);
     }
 
     public MonthlyExpenseSummary getMonthlyExpensesSummary(Long userId, YearMonth yearMonth) {
-        List<LedgerEntry> expenses = getMonthlyExpenses(userId, yearMonth);
+        return getMonthlyExpensesSummary(userId, yearMonth, 1);
+    }
+
+    public MonthlyExpenseSummary getMonthlyExpensesSummary(Long userId, YearMonth yearMonth, int monthStartDay) {
+        List<LedgerEntry> expenses = getMonthlyExpenses(userId, yearMonth, monthStartDay);
         Map<String, BigDecimal> categoryExpenses = new HashMap<>();
         
         // 카테고리별 합계 계산 (실제로는 Category 엔티티와 조인해야 하지만 일단 단순화)
@@ -50,10 +58,14 @@ public class MonthlyExpenseService {
     }
 
     public MonthlyExpenseComparison getMonthlyComparison(Long userId, YearMonth currentMonth) {
+        return getMonthlyComparison(userId, currentMonth, 1);
+    }
+
+    public MonthlyExpenseComparison getMonthlyComparison(Long userId, YearMonth currentMonth, int monthStartDay) {
         YearMonth previousMonth = currentMonth.minusMonths(1);
-        
-        BigDecimal currentTotal = getTotalExpenseForMonth(userId, currentMonth);
-        BigDecimal previousTotal = getTotalExpenseForMonth(userId, previousMonth);
+
+        BigDecimal currentTotal = getTotalExpenseForMonth(userId, currentMonth, monthStartDay);
+        BigDecimal previousTotal = getTotalExpenseForMonth(userId, previousMonth, monthStartDay);
         
         BigDecimal difference = currentTotal.subtract(previousTotal);
         double percentageChange = 0.0;
@@ -72,13 +84,13 @@ public class MonthlyExpenseService {
         );
     }
 
-    private BigDecimal getTotalExpenseForMonth(Long userId, YearMonth yearMonth) {
-        LocalDate startDate = yearMonth.atDay(1);
-        LocalDate endDate = yearMonth.atEndOfMonth();
-        
+    private BigDecimal getTotalExpenseForMonth(Long userId, YearMonth yearMonth, int monthStartDay) {
+        LocalDate startDate = yearMonth.atDay(monthStartDay);
+        LocalDate endDate = startDate.plusMonths(1).minusDays(1);
+
         BigDecimal total = ledgerEntryRepository.sumByUserIdAndEntryTypeAndDateBetween(
             userId, EntryType.EXPENSE, startDate, endDate);
-        
+
         return total != null ? total : BigDecimal.ZERO;
     }
 }

--- a/src/main/java/com/aurfebre/household/service/UserBudgetSettingsService.java
+++ b/src/main/java/com/aurfebre/household/service/UserBudgetSettingsService.java
@@ -1,0 +1,61 @@
+package com.aurfebre.household.service;
+
+import com.aurfebre.household.domain.UserBudgetSettings;
+import com.aurfebre.household.domain.enums.CycleType;
+import com.aurfebre.household.repository.UserBudgetSettingsRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class UserBudgetSettingsService {
+
+    private final UserBudgetSettingsRepository userBudgetSettingsRepository;
+
+    public UserBudgetSettingsService(UserBudgetSettingsRepository userBudgetSettingsRepository) {
+        this.userBudgetSettingsRepository = userBudgetSettingsRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserBudgetSettings> getAllSettings() {
+        return userBudgetSettingsRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<UserBudgetSettings> getSettingsById(Long id) {
+        return userBudgetSettingsRepository.findById(id);
+    }
+
+    public UserBudgetSettings createSettings(UserBudgetSettings settings) {
+        return userBudgetSettingsRepository.save(settings);
+    }
+
+    public UserBudgetSettings updateSettings(Long id, UserBudgetSettings settingsDetails) {
+        UserBudgetSettings settings = userBudgetSettingsRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("UserBudgetSettings not found with id: " + id));
+
+        settings.setMonthStartDay(settingsDetails.getMonthStartDay());
+        settings.setCycleType(settingsDetails.getCycleType());
+        settings.setWeekStartDay(settingsDetails.getWeekStartDay());
+
+        return userBudgetSettingsRepository.save(settings);
+    }
+
+    public void deleteSettings(Long id) {
+        userBudgetSettingsRepository.deleteById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public UserBudgetSettings getSettings(Long userId) {
+        return userBudgetSettingsRepository.findByUserId(userId)
+                .orElseGet(() -> getDefaultSettings(userId));
+    }
+
+    private UserBudgetSettings getDefaultSettings(Long userId) {
+        return new UserBudgetSettings(userId, 1, CycleType.MONTHLY, DayOfWeek.MONDAY);
+    }
+}


### PR DESCRIPTION
## Summary
- add UserBudgetSettings entity with cycle configuration and defaults
- extend monthly expense logic to respect user-defined month start
- wire financial goals and controllers to read month start via UserBudgetSettingsService

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689209f49d2c832eb26ca4f77b918d4a