### PR TITLE
Add user budget settings API and tests

### DIFF
--- a/src/main/java/com/aurfebre/household/api/UserBudgetSettingsController.java
+++ b/src/main/java/com/aurfebre/household/api/UserBudgetSettingsController.java
@@ -1,0 +1,63 @@
+package com.aurfebre.household.api;
+
+import com.aurfebre.household.domain.UserBudgetSettings;
+import com.aurfebre.household.dto.UserBudgetSettingsDto;
+import com.aurfebre.household.mapper.UserBudgetSettingsMapper;
+import com.aurfebre.household.service.UserBudgetSettingsService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.NoSuchElementException;
+
+@RestController
+@RequestMapping("/api/user-settings")
+public class UserBudgetSettingsController {
+
+    private final UserBudgetSettingsService service;
+
+    public UserBudgetSettingsController(UserBudgetSettingsService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserBudgetSettingsDto> getSettings(@PathVariable Long userId) {
+        return service.getSettingsByUserId(userId)
+                .map(UserBudgetSettingsMapper::toDto)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<UserBudgetSettingsDto> createSettings(@RequestBody UserBudgetSettingsDto dto) {
+        try {
+            UserBudgetSettings created = service.createSettings(UserBudgetSettingsMapper.toEntity(dto));
+            return ResponseEntity.status(HttpStatus.CREATED).body(UserBudgetSettingsMapper.toDto(created));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @PutMapping("/{userId}")
+    public ResponseEntity<UserBudgetSettingsDto> updateSettings(@PathVariable Long userId,
+                                                                 @RequestBody UserBudgetSettingsDto dto) {
+        try {
+            UserBudgetSettings updated = service.updateSettings(userId, UserBudgetSettingsMapper.toEntity(dto));
+            return ResponseEntity.ok(UserBudgetSettingsMapper.toDto(updated));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<Void> deleteSettings(@PathVariable Long userId) {
+        try {
+            service.deleteSettings(userId);
+            return ResponseEntity.noContent().build();
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/src/main/java/com/aurfebre/household/domain/UserBudgetSettings.java
+++ b/src/main/java/com/aurfebre/household/domain/UserBudgetSettings.java
@@ -1,0 +1,77 @@
+package com.aurfebre.household.domain;
+
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_budget_settings")
+public class UserBudgetSettings {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Integer monthStartDay;
+
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal monthlySalary;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    public UserBudgetSettings() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public UserBudgetSettings(Long userId, Integer monthStartDay, BigDecimal monthlySalary) {
+        this();
+        this.userId = userId;
+        this.monthStartDay = monthStartDay;
+        this.monthlySalary = monthlySalary;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Integer getMonthStartDay() {
+        return monthStartDay;
+    }
+
+    public void setMonthStartDay(Integer monthStartDay) {
+        this.monthStartDay = monthStartDay;
+    }
+
+    public BigDecimal getMonthlySalary() {
+        return monthlySalary;
+    }
+
+    public void setMonthlySalary(BigDecimal monthlySalary) {
+        this.monthlySalary = monthlySalary;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/aurfebre/household/dto/UserBudgetSettingsDto.java
+++ b/src/main/java/com/aurfebre/household/dto/UserBudgetSettingsDto.java
@@ -1,0 +1,42 @@
+package com.aurfebre.household.dto;
+
+import java.math.BigDecimal;
+
+public class UserBudgetSettingsDto {
+    private Long userId;
+    private Integer monthStartDay;
+    private BigDecimal monthlySalary;
+
+    public UserBudgetSettingsDto() {
+    }
+
+    public UserBudgetSettingsDto(Long userId, Integer monthStartDay, BigDecimal monthlySalary) {
+        this.userId = userId;
+        this.monthStartDay = monthStartDay;
+        this.monthlySalary = monthlySalary;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Integer getMonthStartDay() {
+        return monthStartDay;
+    }
+
+    public void setMonthStartDay(Integer monthStartDay) {
+        this.monthStartDay = monthStartDay;
+    }
+
+    public BigDecimal getMonthlySalary() {
+        return monthlySalary;
+    }
+
+    public void setMonthlySalary(BigDecimal monthlySalary) {
+        this.monthlySalary = monthlySalary;
+    }
+}

--- a/src/main/java/com/aurfebre/household/mapper/UserBudgetSettingsMapper.java
+++ b/src/main/java/com/aurfebre/household/mapper/UserBudgetSettingsMapper.java
@@ -1,0 +1,28 @@
+package com.aurfebre.household.mapper;
+
+import com.aurfebre.household.domain.UserBudgetSettings;
+import com.aurfebre.household.dto.UserBudgetSettingsDto;
+
+public class UserBudgetSettingsMapper {
+    public static UserBudgetSettingsDto toDto(UserBudgetSettings settings) {
+        if (settings == null) {
+            return null;
+        }
+        return new UserBudgetSettingsDto(
+                settings.getUserId(),
+                settings.getMonthStartDay(),
+                settings.getMonthlySalary()
+        );
+    }
+
+    public static UserBudgetSettings toEntity(UserBudgetSettingsDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        return new UserBudgetSettings(
+                dto.getUserId(),
+                dto.getMonthStartDay(),
+                dto.getMonthlySalary()
+        );
+    }
+}

--- a/src/main/java/com/aurfebre/household/repository/UserBudgetSettingsRepository.java
+++ b/src/main/java/com/aurfebre/household/repository/UserBudgetSettingsRepository.java
@@ -1,0 +1,11 @@
+package com.aurfebre.household.repository;
+
+import com.aurfebre.household.domain.UserBudgetSettings;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserBudgetSettingsRepository extends JpaRepository<UserBudgetSettings, Long> {
+    Optional<UserBudgetSettings> findByUserId(Long userId);
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/aurfebre/household/service/UserBudgetSettingsService.java
+++ b/src/main/java/com/aurfebre/household/service/UserBudgetSettingsService.java
@@ -1,0 +1,53 @@
+package com.aurfebre.household.service;
+
+import com.aurfebre.household.domain.UserBudgetSettings;
+import com.aurfebre.household.repository.UserBudgetSettingsRepository;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Service
+public class UserBudgetSettingsService {
+
+    private final UserBudgetSettingsRepository repository;
+
+    public UserBudgetSettingsService(UserBudgetSettingsRepository repository) {
+        this.repository = repository;
+    }
+
+    public Optional<UserBudgetSettings> getSettingsByUserId(Long userId) {
+        return repository.findByUserId(userId);
+    }
+
+    public UserBudgetSettings createSettings(UserBudgetSettings settings) {
+        validate(settings);
+        return repository.save(settings);
+    }
+
+    public UserBudgetSettings updateSettings(Long userId, UserBudgetSettings settings) {
+        validate(settings);
+        UserBudgetSettings existing = repository.findByUserId(userId)
+                .orElseThrow(NoSuchElementException::new);
+        existing.setMonthStartDay(settings.getMonthStartDay());
+        existing.setMonthlySalary(settings.getMonthlySalary());
+        return repository.save(existing);
+    }
+
+    public void deleteSettings(Long userId) {
+        UserBudgetSettings existing = repository.findByUserId(userId)
+                .orElseThrow(NoSuchElementException::new);
+        repository.delete(existing);
+    }
+
+    private void validate(UserBudgetSettings settings) {
+        if (settings.getMonthStartDay() != null && settings.getMonthStartDay() > 28) {
+            throw new IllegalArgumentException("monthStartDay must be 28 or less");
+        }
+        BigDecimal salary = settings.getMonthlySalary();
+        if (salary != null && salary.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("monthlySalary must be positive");
+        }
+    }
+}

--- a/src/test/java/com/aurfebre/household/api/UserBudgetSettingsControllerTest.java
+++ b/src/test/java/com/aurfebre/household/api/UserBudgetSettingsControllerTest.java
@@ -1,0 +1,122 @@
+package com.aurfebre.household.api;
+
+import com.aurfebre.household.domain.UserBudgetSettings;
+import com.aurfebre.household.dto.UserBudgetSettingsDto;
+import com.aurfebre.household.service.UserBudgetSettingsService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserBudgetSettingsController.class)
+@Import(com.aurfebre.household.config.SecurityConfig.class)
+class UserBudgetSettingsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserBudgetSettingsService userBudgetSettingsService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private UserBudgetSettings settings;
+    private UserBudgetSettingsDto dto;
+
+    @BeforeEach
+    void setUp() {
+        settings = new UserBudgetSettings(1L, 5, new BigDecimal("1000"));
+        dto = new UserBudgetSettingsDto(1L, 5, new BigDecimal("1000"));
+    }
+
+    @Test
+    void getSettings_ShouldReturnSettings() throws Exception {
+        when(userBudgetSettingsService.getSettingsByUserId(1L)).thenReturn(Optional.of(settings));
+
+        mockMvc.perform(get("/api/user-settings/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1))
+                .andExpect(jsonPath("$.monthStartDay").value(5))
+                .andExpect(jsonPath("$.monthlySalary").value(1000));
+    }
+
+    @Test
+    void getSettings_WhenNotFound_ShouldReturn404() throws Exception {
+        when(userBudgetSettingsService.getSettingsByUserId(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/user-settings/1"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void createSettings_ShouldReturnCreated() throws Exception {
+        when(userBudgetSettingsService.createSettings(any(UserBudgetSettings.class))).thenReturn(settings);
+
+        mockMvc.perform(post("/api/user-settings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.userId").value(1))
+                .andExpect(jsonPath("$.monthStartDay").value(5));
+    }
+
+    @Test
+    void createSettings_WhenInvalidMonthStartDay_ShouldReturnBadRequest() throws Exception {
+        when(userBudgetSettingsService.createSettings(any(UserBudgetSettings.class)))
+                .thenThrow(new IllegalArgumentException("monthStartDay must be 28 or less"));
+        UserBudgetSettingsDto invalidDto = new UserBudgetSettingsDto(1L, 29, new BigDecimal("1000"));
+
+        mockMvc.perform(post("/api/user-settings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidDto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void updateSettings_ShouldReturnUpdated() throws Exception {
+        when(userBudgetSettingsService.updateSettings(eq(1L), any(UserBudgetSettings.class))).thenReturn(settings);
+
+        mockMvc.perform(put("/api/user-settings/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1))
+                .andExpect(jsonPath("$.monthlySalary").value(1000));
+    }
+
+    @Test
+    void updateSettings_WhenNegativeSalary_ShouldReturnBadRequest() throws Exception {
+        when(userBudgetSettingsService.updateSettings(eq(1L), any(UserBudgetSettings.class)))
+                .thenThrow(new IllegalArgumentException("monthlySalary must be positive"));
+        UserBudgetSettingsDto invalidDto = new UserBudgetSettingsDto(1L, 5, new BigDecimal("-100"));
+
+        mockMvc.perform(put("/api/user-settings/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidDto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void deleteSettings_ShouldReturnNoContent() throws Exception {
+        doNothing().when(userBudgetSettingsService).deleteSettings(1L);
+
+        mockMvc.perform(delete("/api/user-settings/1"))
+                .andExpect(status().isNoContent());
+    }
+}


### PR DESCRIPTION
## Summary
- implement user budget settings CRUD endpoints
- add DTO and mapper for serialization
- validate month start day and salary values
- provide unit tests for controller

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.5.3'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689209f63650832e9be3bc6812b7d22c