### PR TITLE
feat: add weekly budget support

### DIFF
--- a/src/main/java/com/aurfebre/household/api/UserBudgetSettingsController.java
+++ b/src/main/java/com/aurfebre/household/api/UserBudgetSettingsController.java
@@ -1,0 +1,53 @@
+package com.aurfebre.household.api;
+
+import com.aurfebre.household.domain.UserBudgetSettings;
+import com.aurfebre.household.service.UserBudgetSettingsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+
+@RestController
+@RequestMapping("/api/user-budget-settings")
+public class UserBudgetSettingsController {
+
+    private final UserBudgetSettingsService service;
+
+    public UserBudgetSettingsController(UserBudgetSettingsService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<UserBudgetSettings> getSettings(@PathVariable Long userId) {
+        return service.getSettings(userId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/user/{userId}")
+    public UserBudgetSettings updateSettings(@PathVariable Long userId, @RequestBody SettingsRequest request) {
+        return service.updateSettings(userId, request.getAnnualSalary(), request.getWeekStartDay());
+    }
+
+    public static class SettingsRequest {
+        private BigDecimal annualSalary;
+        private DayOfWeek weekStartDay;
+
+        public BigDecimal getAnnualSalary() {
+            return annualSalary;
+        }
+
+        public void setAnnualSalary(BigDecimal annualSalary) {
+            this.annualSalary = annualSalary;
+        }
+
+        public DayOfWeek getWeekStartDay() {
+            return weekStartDay;
+        }
+
+        public void setWeekStartDay(DayOfWeek weekStartDay) {
+            this.weekStartDay = weekStartDay;
+        }
+    }
+}

--- a/src/main/java/com/aurfebre/household/api/WeeklyBudgetController.java
+++ b/src/main/java/com/aurfebre/household/api/WeeklyBudgetController.java
@@ -1,0 +1,40 @@
+package com.aurfebre.household.api;
+
+import com.aurfebre.household.dto.WeeklyBudgetResponse;
+import com.aurfebre.household.service.FinancialGoalService;
+import com.aurfebre.household.service.UserBudgetSettingsService;
+import com.aurfebre.household.service.WeeklyBudgetService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/weekly-budget")
+public class WeeklyBudgetController {
+
+    private final WeeklyBudgetService weeklyBudgetService;
+    private final UserBudgetSettingsService settingsService;
+    private final FinancialGoalService financialGoalService;
+
+    public WeeklyBudgetController(WeeklyBudgetService weeklyBudgetService,
+                                  UserBudgetSettingsService settingsService,
+                                  FinancialGoalService financialGoalService) {
+        this.weeklyBudgetService = weeklyBudgetService;
+        this.settingsService = settingsService;
+        this.financialGoalService = financialGoalService;
+    }
+
+    @GetMapping("/user/{userId}")
+    public WeeklyBudgetResponse getWeeklyBudget(@PathVariable Long userId,
+                                                @RequestParam(required = false)
+                                                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate currentWeek) {
+        LocalDate week = currentWeek != null ? currentWeek : LocalDate.now();
+        var settings = settingsService.getSettings(userId)
+                .orElseThrow(() -> new IllegalArgumentException("Settings not found for user: " + userId));
+        var summary = weeklyBudgetService.calculateWeeklyBudget(userId, settings.getAnnualSalary(), settings.getWeekStartDay(), week);
+        var goals = financialGoalService.getGoalsForWeek(userId, settings.getWeekStartDay(), week);
+        return new WeeklyBudgetResponse(summary.getWeeklyBudget(), summary.getWeeklySpending(),
+                summary.getStartDate(), summary.getEndDate(), goals);
+    }
+}

--- a/src/main/java/com/aurfebre/household/domain/UserBudgetSettings.java
+++ b/src/main/java/com/aurfebre/household/domain/UserBudgetSettings.java
@@ -1,0 +1,65 @@
+package com.aurfebre.household.domain;
+
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+
+@Entity
+@Table(name = "user_budget_settings")
+public class UserBudgetSettings {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal annualSalary;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DayOfWeek weekStartDay;
+
+    public UserBudgetSettings() {
+    }
+
+    public UserBudgetSettings(Long userId, BigDecimal annualSalary, DayOfWeek weekStartDay) {
+        this.userId = userId;
+        this.annualSalary = annualSalary;
+        this.weekStartDay = weekStartDay;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public BigDecimal getAnnualSalary() {
+        return annualSalary;
+    }
+
+    public void setAnnualSalary(BigDecimal annualSalary) {
+        this.annualSalary = annualSalary;
+    }
+
+    public DayOfWeek getWeekStartDay() {
+        return weekStartDay;
+    }
+
+    public void setWeekStartDay(DayOfWeek weekStartDay) {
+        this.weekStartDay = weekStartDay;
+    }
+}

--- a/src/main/java/com/aurfebre/household/dto/WeeklyBudgetResponse.java
+++ b/src/main/java/com/aurfebre/household/dto/WeeklyBudgetResponse.java
@@ -1,0 +1,67 @@
+package com.aurfebre.household.dto;
+
+import com.aurfebre.household.domain.FinancialGoal;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+public class WeeklyBudgetResponse {
+
+    private BigDecimal weeklyBudget;
+    private BigDecimal weeklySpending;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private List<FinancialGoal> goals;
+
+    public WeeklyBudgetResponse() {
+    }
+
+    public WeeklyBudgetResponse(BigDecimal weeklyBudget, BigDecimal weeklySpending, LocalDate startDate, LocalDate endDate, List<FinancialGoal> goals) {
+        this.weeklyBudget = weeklyBudget;
+        this.weeklySpending = weeklySpending;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.goals = goals;
+    }
+
+    public BigDecimal getWeeklyBudget() {
+        return weeklyBudget;
+    }
+
+    public void setWeeklyBudget(BigDecimal weeklyBudget) {
+        this.weeklyBudget = weeklyBudget;
+    }
+
+    public BigDecimal getWeeklySpending() {
+        return weeklySpending;
+    }
+
+    public void setWeeklySpending(BigDecimal weeklySpending) {
+        this.weeklySpending = weeklySpending;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public List<FinancialGoal> getGoals() {
+        return goals;
+    }
+
+    public void setGoals(List<FinancialGoal> goals) {
+        this.goals = goals;
+    }
+}

--- a/src/main/java/com/aurfebre/household/repository/UserBudgetSettingsRepository.java
+++ b/src/main/java/com/aurfebre/household/repository/UserBudgetSettingsRepository.java
@@ -1,0 +1,12 @@
+package com.aurfebre.household.repository;
+
+import com.aurfebre.household.domain.UserBudgetSettings;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserBudgetSettingsRepository extends JpaRepository<UserBudgetSettings, Long> {
+    Optional<UserBudgetSettings> findByUserId(Long userId);
+}

--- a/src/main/java/com/aurfebre/household/service/BudgetService.java
+++ b/src/main/java/com/aurfebre/household/service/BudgetService.java
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,6 +36,17 @@ public class BudgetService {
     @Transactional(readOnly = true)
     public List<Budget> getBudgetsByUserIdAndPeriod(Long userId, BudgetPeriod period) {
         return budgetRepository.findByUserIdAndPeriodAndIsActiveTrueOrderByStartDateDesc(userId, period);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Budget> getBudgetsForWeek(Long userId, DayOfWeek weekStartDay, LocalDate currentWeek) {
+        LocalDate start = currentWeek.with(TemporalAdjusters.previousOrSame(weekStartDay));
+        LocalDate end = start.plusDays(6);
+        return budgetRepository
+                .findByUserIdAndPeriodAndIsActiveTrueOrderByStartDateDesc(userId, BudgetPeriod.WEEKLY)
+                .stream()
+                .filter(b -> !b.getEndDate().isBefore(start) && !b.getStartDate().isAfter(end))
+                .toList();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/aurfebre/household/service/FinancialGoalService.java
+++ b/src/main/java/com/aurfebre/household/service/FinancialGoalService.java
@@ -1,0 +1,31 @@
+package com.aurfebre.household.service;
+
+import com.aurfebre.household.domain.FinancialGoal;
+import com.aurfebre.household.repository.FinancialGoalRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class FinancialGoalService {
+
+    private final FinancialGoalRepository repository;
+
+    public FinancialGoalService(FinancialGoalRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<FinancialGoal> getGoalsForWeek(Long userId, DayOfWeek weekStartDay, LocalDate currentWeek) {
+        LocalDate start = currentWeek.with(TemporalAdjusters.previousOrSame(weekStartDay));
+        LocalDate end = start.plusDays(6);
+        return repository.findGoalsDueByDate(userId, end).stream()
+                .filter(goal -> !goal.getTargetDate().isBefore(start))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/aurfebre/household/service/UserBudgetSettingsService.java
+++ b/src/main/java/com/aurfebre/household/service/UserBudgetSettingsService.java
@@ -1,0 +1,34 @@
+package com.aurfebre.household.service;
+
+import com.aurfebre.household.domain.UserBudgetSettings;
+import com.aurfebre.household.repository.UserBudgetSettingsRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class UserBudgetSettingsService {
+
+    private final UserBudgetSettingsRepository repository;
+
+    public UserBudgetSettingsService(UserBudgetSettingsRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<UserBudgetSettings> getSettings(Long userId) {
+        return repository.findByUserId(userId);
+    }
+
+    public UserBudgetSettings updateSettings(Long userId, BigDecimal annualSalary, DayOfWeek weekStartDay) {
+        UserBudgetSettings settings = repository.findByUserId(userId)
+                .orElse(new UserBudgetSettings(userId, annualSalary, weekStartDay));
+        settings.setAnnualSalary(annualSalary);
+        settings.setWeekStartDay(weekStartDay);
+        return repository.save(settings);
+    }
+}

--- a/src/main/java/com/aurfebre/household/service/WeeklyBudgetService.java
+++ b/src/main/java/com/aurfebre/household/service/WeeklyBudgetService.java
@@ -1,0 +1,64 @@
+package com.aurfebre.household.service;
+
+import com.aurfebre.household.domain.enums.EntryType;
+import com.aurfebre.household.repository.LedgerEntryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+
+@Service
+@Transactional(readOnly = true)
+public class WeeklyBudgetService {
+
+    private final LedgerEntryRepository ledgerEntryRepository;
+
+    public WeeklyBudgetService(LedgerEntryRepository ledgerEntryRepository) {
+        this.ledgerEntryRepository = ledgerEntryRepository;
+    }
+
+    public WeeklyBudgetSummary calculateWeeklyBudget(Long userId, BigDecimal annualSalary, DayOfWeek weekStartDay, LocalDate currentWeek) {
+        BigDecimal weeklyBudget = annualSalary.divide(BigDecimal.valueOf(52), 2, RoundingMode.HALF_UP);
+        LocalDate start = currentWeek.with(TemporalAdjusters.previousOrSame(weekStartDay));
+        LocalDate end = start.plusDays(6);
+        BigDecimal spent = ledgerEntryRepository.sumByUserIdAndEntryTypeAndDateBetween(userId, EntryType.EXPENSE, start, end);
+        if (spent == null) {
+            spent = BigDecimal.ZERO;
+        }
+        return new WeeklyBudgetSummary(weeklyBudget, spent, start, end);
+    }
+
+    public static class WeeklyBudgetSummary {
+        private final BigDecimal weeklyBudget;
+        private final BigDecimal weeklySpending;
+        private final LocalDate startDate;
+        private final LocalDate endDate;
+
+        public WeeklyBudgetSummary(BigDecimal weeklyBudget, BigDecimal weeklySpending, LocalDate startDate, LocalDate endDate) {
+            this.weeklyBudget = weeklyBudget;
+            this.weeklySpending = weeklySpending;
+            this.startDate = startDate;
+            this.endDate = endDate;
+        }
+
+        public BigDecimal getWeeklyBudget() {
+            return weeklyBudget;
+        }
+
+        public BigDecimal getWeeklySpending() {
+            return weeklySpending;
+        }
+
+        public LocalDate getStartDate() {
+            return startDate;
+        }
+
+        public LocalDate getEndDate() {
+            return endDate;
+        }
+    }
+}

--- a/src/test/java/com/aurfebre/household/service/BudgetServiceTest.java
+++ b/src/test/java/com/aurfebre/household/service/BudgetServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -94,6 +95,21 @@ class BudgetServiceTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getPeriod()).isEqualTo(BudgetPeriod.MONTHLY);
         verify(budgetRepository).findByUserIdAndPeriodAndIsActiveTrueOrderByStartDateDesc(1L, BudgetPeriod.MONTHLY);
+    }
+
+    @Test
+    void getBudgetsForWeek_ShouldReturnBudgetsWithinWeek() {
+        Budget weeklyBudget = new Budget(
+            1L, 2L, BudgetPeriod.WEEKLY, new BigDecimal("100000"),
+            LocalDate.of(2024,1,1), LocalDate.of(2024,1,7)
+        );
+        when(budgetRepository.findByUserIdAndPeriodAndIsActiveTrueOrderByStartDateDesc(1L, BudgetPeriod.WEEKLY))
+            .thenReturn(Arrays.asList(weeklyBudget));
+
+        List<Budget> result = budgetService.getBudgetsForWeek(1L, DayOfWeek.MONDAY, LocalDate.of(2024,1,3));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).isEqualTo(weeklyBudget);
     }
 
     @Test

--- a/src/test/java/com/aurfebre/household/service/FinancialGoalServiceTest.java
+++ b/src/test/java/com/aurfebre/household/service/FinancialGoalServiceTest.java
@@ -1,0 +1,42 @@
+package com.aurfebre.household.service;
+
+import com.aurfebre.household.domain.FinancialGoal;
+import com.aurfebre.household.domain.enums.GoalType;
+import com.aurfebre.household.repository.FinancialGoalRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FinancialGoalServiceTest {
+
+    @Mock
+    private FinancialGoalRepository financialGoalRepository;
+
+    @InjectMocks
+    private FinancialGoalService financialGoalService;
+
+    @Test
+    void getGoalsForWeek_ShouldFilterByWeekRange() {
+        FinancialGoal goal1 = new FinancialGoal(1L, GoalType.SAVING, "Goal1", new BigDecimal("1000"),
+                LocalDate.of(2024,1,4), 1);
+        FinancialGoal goal2 = new FinancialGoal(1L, GoalType.SAVING, "Goal2", new BigDecimal("2000"),
+                LocalDate.of(2024,1,10), 1);
+        when(financialGoalRepository.findGoalsDueByDate(1L, LocalDate.of(2024,1,7)))
+                .thenReturn(List.of(goal1));
+
+        List<FinancialGoal> result = financialGoalService.getGoalsForWeek(1L, DayOfWeek.MONDAY, LocalDate.of(2024,1,3));
+
+        assertThat(result).containsExactly(goal1);
+    }
+}

--- a/src/test/java/com/aurfebre/household/service/WeeklyBudgetServiceTest.java
+++ b/src/test/java/com/aurfebre/household/service/WeeklyBudgetServiceTest.java
@@ -1,0 +1,41 @@
+package com.aurfebre.household.service;
+
+import com.aurfebre.household.domain.enums.EntryType;
+import com.aurfebre.household.repository.LedgerEntryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WeeklyBudgetServiceTest {
+
+    @Mock
+    private LedgerEntryRepository ledgerEntryRepository;
+
+    @InjectMocks
+    private WeeklyBudgetService weeklyBudgetService;
+
+    @Test
+    void calculateWeeklyBudget_ShouldReturnBudgetAndSpending() {
+        when(ledgerEntryRepository.sumByUserIdAndEntryTypeAndDateBetween(eq(1L), eq(EntryType.EXPENSE), any(), any()))
+                .thenReturn(new BigDecimal("200"));
+
+        var summary = weeklyBudgetService.calculateWeeklyBudget(1L, new BigDecimal("52000"),
+                DayOfWeek.MONDAY, LocalDate.of(2024, 1, 3));
+
+        assertThat(summary.getWeeklyBudget()).isEqualByComparingTo("1000.00");
+        assertThat(summary.getWeeklySpending()).isEqualByComparingTo("200");
+        assertThat(summary.getStartDate()).isEqualTo(LocalDate.of(2024, 1, 1));
+        assertThat(summary.getEndDate()).isEqualTo(LocalDate.of(2024, 1, 7));
+    }
+}


### PR DESCRIPTION
## Summary
- support weekly budget calculations and goal filtering
- allow updating annual salary and week start settings
- expose endpoints for weekly budget info and settings

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689209f58fc8832e92ba4a147c4ff313