### PR TITLE
Add weekly income calculation and update projection API

### DIFF
--- a/src/main/java/com/aurfebre/household/api/IncomeProjectionController.java
+++ b/src/main/java/com/aurfebre/household/api/IncomeProjectionController.java
@@ -99,13 +99,15 @@ public class IncomeProjectionController {
         
         int monthCount = endMonth - startMonth + 1;
         BigDecimal annualIncome = monthlyIncome.multiply(BigDecimal.valueOf(monthCount));
+        BigDecimal weeklyIncome = incomeProjectionService.calculateWeeklyIncome(monthlyIncome);
         
         return ResponseEntity.ok(Map.of(
                 "monthlyIncome", monthlyIncome,
                 "startMonth", startMonth,
                 "endMonth", endMonth,
                 "monthCount", monthCount,
-                "projectedAnnualIncome", annualIncome
+                "projectedAnnualIncome", annualIncome,
+                "projectedWeeklyIncome", weeklyIncome
         ));
     }
 }

--- a/src/main/java/com/aurfebre/household/service/IncomeProjectionService.java
+++ b/src/main/java/com/aurfebre/household/service/IncomeProjectionService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -171,6 +172,10 @@ public class IncomeProjectionService {
                 .stream()
                 .map(IncomeProjectionResponse::from)
                 .collect(Collectors.toList());
+    }
+
+    public BigDecimal calculateWeeklyIncome(BigDecimal monthlyIncome) {
+        return monthlyIncome.divide(BigDecimal.valueOf(4.345), 2, RoundingMode.HALF_UP);
     }
 
     private BigDecimal calculateAnnualIncome(BigDecimal monthlyIncome, Integer startMonth, Integer endMonth) {

--- a/src/test/java/com/aurfebre/household/service/IncomeProjectionServiceTest.java
+++ b/src/test/java/com/aurfebre/household/service/IncomeProjectionServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -72,5 +73,15 @@ class IncomeProjectionServiceTest {
 
         assertThat(result).isEqualByComparingTo(BigDecimal.ZERO);
         verify(incomeProjectionRepository).sumProjectedIncomeByUserIdAndYear(1L, 2025);
+    }
+
+    @Test
+    void calculateWeeklyIncome_ShouldConvertMonthlyToWeekly() {
+        BigDecimal monthlyIncome = new BigDecimal("1000");
+        BigDecimal expected = monthlyIncome.divide(BigDecimal.valueOf(4.345), 2, RoundingMode.HALF_UP);
+
+        BigDecimal result = incomeProjectionService.calculateWeeklyIncome(monthlyIncome);
+
+        assertThat(result).isEqualByComparingTo(expected);
     }
 }


### PR DESCRIPTION
## Summary
- add calculateWeeklyIncome to convert monthly income to weekly estimates
- extend income projection API to return weekly income
- verify monthly to weekly conversion via unit test

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.5.3'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68936ea11b6c832e94f47175b0cbcfce