### PR TITLE
Add tests for expense, category, income projection, and user controllers

### DIFF
--- a/src/test/java/com/aurfebre/household/api/CategoryControllerTest.java
+++ b/src/test/java/com/aurfebre/household/api/CategoryControllerTest.java
@@ -1,0 +1,115 @@
+package com.aurfebre.household.api;
+
+import com.aurfebre.household.domain.Category;
+import com.aurfebre.household.domain.enums.CategoryType;
+import com.aurfebre.household.domain.enums.SubCategoryType;
+import com.aurfebre.household.service.CategoryService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(CategoryController.class)
+@Import(com.aurfebre.household.config.SecurityConfig.class)
+class CategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CategoryService categoryService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Category testCategory;
+
+    @BeforeEach
+    void setUp() {
+        testCategory = new Category(1L, "Food", CategoryType.EXPENSE, SubCategoryType.VARIABLE_EXPENSE);
+        testCategory.setId(1L);
+        testCategory.setCreatedAt(LocalDateTime.now());
+    }
+
+    @Test
+    void getAllCategories_ShouldReturnAllCategories() throws Exception {
+        when(categoryService.getAllCategories()).thenReturn(Collections.singletonList(testCategory));
+
+        mockMvc.perform(get("/api/categories"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].id", is(1)))
+                .andExpect(jsonPath("$[0].name", is("Food")));
+    }
+
+    @Test
+    void getCategoryById_WhenExists_ShouldReturnCategory() throws Exception {
+        when(categoryService.getCategoryById(1L)).thenReturn(Optional.of(testCategory));
+
+        mockMvc.perform(get("/api/categories/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(1)));
+    }
+
+    @Test
+    void getCategoryById_WhenNotExists_ShouldReturnNotFound() throws Exception {
+        when(categoryService.getCategoryById(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/categories/1"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void createCategory_WhenValid_ShouldReturnCreated() throws Exception {
+        when(categoryService.createCategory(any(Category.class))).thenReturn(testCategory);
+
+        mockMvc.perform(post("/api/categories")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(testCategory)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id", is(1)));
+    }
+
+    @Test
+    void updateCategory_WhenNotFound_ShouldReturnNotFound() throws Exception {
+        when(categoryService.updateCategory(eq(99L), any(Category.class)))
+                .thenThrow(new IllegalArgumentException("Category not found"));
+
+        mockMvc.perform(put("/api/categories/99")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(testCategory)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getCategoriesByUserIdAndType_WhenInvalidType_ShouldReturnBadRequest() throws Exception {
+        mockMvc.perform(get("/api/categories/user/1/type/INVALID"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void deleteCategory_WhenNotFound_ShouldReturnNotFound() throws Exception {
+        doThrow(new IllegalArgumentException("Category not found")).when(categoryService).deleteCategory(99L);
+
+        mockMvc.perform(delete("/api/categories/99"))
+                .andExpect(status().isNotFound());
+    }
+}
+

--- a/src/test/java/com/aurfebre/household/api/ExpenseControllerTest.java
+++ b/src/test/java/com/aurfebre/household/api/ExpenseControllerTest.java
@@ -1,0 +1,79 @@
+package com.aurfebre.household.api;
+
+import com.aurfebre.household.domain.Expense;
+import com.aurfebre.household.service.ExpenseService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ExpenseController.class)
+@Import(com.aurfebre.household.config.SecurityConfig.class)
+class ExpenseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ExpenseService expenseService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Expense testExpense;
+
+    @BeforeEach
+    void setUp() {
+        testExpense = new Expense("Lunch", 15000, "Food");
+        testExpense.setId(1L);
+        testExpense.setCreatedAt(LocalDateTime.now());
+    }
+
+    @Test
+    void getAllExpenses_ShouldReturnAllExpenses() throws Exception {
+        when(expenseService.getAllExpenses()).thenReturn(Collections.singletonList(testExpense));
+
+        mockMvc.perform(get("/api/expenses"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].id", is(1)))
+                .andExpect(jsonPath("$[0].description", is("Lunch")));
+    }
+
+    @Test
+    void createExpense_WhenValid_ShouldReturnCreated() throws Exception {
+        when(expenseService.createExpense(any(Expense.class))).thenReturn(testExpense);
+
+        mockMvc.perform(post("/api/expenses")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(testExpense)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id", is(1)))
+                .andExpect(jsonPath("$.description", is("Lunch")));
+    }
+
+    @Test
+    void createExpense_WhenInvalidAmount_ShouldReturnBadRequest() throws Exception {
+        String invalidJson = "{\"description\":\"Lunch\",\"amount\":\"abc\",\"category\":\"Food\"}";
+
+        mockMvc.perform(post("/api/expenses")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidJson))
+                .andExpect(status().isBadRequest());
+    }
+}
+

--- a/src/test/java/com/aurfebre/household/api/IncomeProjectionControllerTest.java
+++ b/src/test/java/com/aurfebre/household/api/IncomeProjectionControllerTest.java
@@ -1,0 +1,128 @@
+package com.aurfebre.household.api;
+
+import com.aurfebre.household.domain.IncomeProjection;
+import com.aurfebre.household.dto.IncomeProjectionRequest;
+import com.aurfebre.household.dto.IncomeProjectionResponse;
+import com.aurfebre.household.service.IncomeProjectionService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(IncomeProjectionController.class)
+@Import(com.aurfebre.household.config.SecurityConfig.class)
+class IncomeProjectionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private IncomeProjectionService incomeProjectionService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private IncomeProjectionRequest validRequest;
+    private IncomeProjectionResponse testResponse;
+
+    @BeforeEach
+    void setUp() {
+        validRequest = IncomeProjectionRequest.builder()
+                .monthlyIncome(new BigDecimal("5000"))
+                .year(2025)
+                .startMonth(1)
+                .endMonth(12)
+                .incomeType(IncomeProjection.IncomeType.SALARY)
+                .description("Test")
+                .build();
+
+        testResponse = IncomeProjectionResponse.builder()
+                .id(1L)
+                .userId(1L)
+                .monthlyIncome(new BigDecimal("5000"))
+                .year(2025)
+                .projectedAnnualIncome(new BigDecimal("60000"))
+                .startMonth(1)
+                .endMonth(12)
+                .incomeType(IncomeProjection.IncomeType.SALARY)
+                .description("Test")
+                .isActive(true)
+                .build();
+    }
+
+    @Test
+    void createProjection_WhenValid_ShouldReturnCreated() throws Exception {
+        when(incomeProjectionService.createProjection(any(IncomeProjectionRequest.class))).thenReturn(testResponse);
+
+        mockMvc.perform(post("/api/income-projections")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(validRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id", is(1)))
+                .andExpect(jsonPath("$.projectedAnnualIncome", is(60000)));
+    }
+
+    @Test
+    void createProjection_WhenInvalidMonthRange_ShouldReturnBadRequest() throws Exception {
+        IncomeProjectionRequest invalidRequest = IncomeProjectionRequest.builder()
+                .monthlyIncome(new BigDecimal("5000"))
+                .year(2025)
+                .startMonth(5)
+                .endMonth(3)
+                .incomeType(IncomeProjection.IncomeType.SALARY)
+                .build();
+
+        mockMvc.perform(post("/api/income-projections")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getProjectionsByYear_WhenInvalidYear_ShouldReturnBadRequest() throws Exception {
+        mockMvc.perform(get("/api/income-projections/year/2010"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getProjectionsByYearRange_WhenStartGreaterThanEnd_ShouldReturnBadRequest() throws Exception {
+        mockMvc.perform(get("/api/income-projections/range")
+                .param("startYear", "2025")
+                .param("endYear", "2024"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void calculateAnnualIncome_WhenStartMonthAfterEndMonth_ShouldReturnBadRequest() throws Exception {
+        mockMvc.perform(post("/api/income-projections/calculate")
+                .param("monthlyIncome", "5000")
+                .param("startMonth", "6")
+                .param("endMonth", "3"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void calculateAnnualIncome_WithValidInput_ShouldReturnProjectedIncome() throws Exception {
+        mockMvc.perform(post("/api/income-projections/calculate")
+                .param("monthlyIncome", "5000")
+                .param("startMonth", "1")
+                .param("endMonth", "3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.projectedAnnualIncome", is(15000)))
+                .andExpect(jsonPath("$.monthCount", is(3)));
+    }
+}
+

--- a/src/test/java/com/aurfebre/household/api/UserControllerTest.java
+++ b/src/test/java/com/aurfebre/household/api/UserControllerTest.java
@@ -1,0 +1,114 @@
+package com.aurfebre.household.api;
+
+import com.aurfebre.household.domain.User;
+import com.aurfebre.household.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+@Import(com.aurfebre.household.config.SecurityConfig.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User("test@example.com", "Test User");
+        testUser.setId(1L);
+        testUser.setCreatedAt(LocalDateTime.now());
+        testUser.setUpdatedAt(LocalDateTime.now());
+    }
+
+    @Test
+    void getAllUsers_ShouldReturnAllUsers() throws Exception {
+        when(userService.getAllUsers()).thenReturn(Collections.singletonList(testUser));
+
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].id", is(1)))
+                .andExpect(jsonPath("$[0].email", is("test@example.com")));
+    }
+
+    @Test
+    void getUserById_WhenExists_ShouldReturnUser() throws Exception {
+        when(userService.getUserById(1L)).thenReturn(Optional.of(testUser));
+
+        mockMvc.perform(get("/api/users/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(1)));
+    }
+
+    @Test
+    void getUserById_WhenNotExists_ShouldReturnNotFound() throws Exception {
+        when(userService.getUserById(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/users/1"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void createUser_WhenValid_ShouldReturnCreated() throws Exception {
+        when(userService.createUser(any(User.class))).thenReturn(testUser);
+
+        mockMvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(testUser)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id", is(1)));
+    }
+
+    @Test
+    void updateUser_WhenNotFound_ShouldReturnNotFound() throws Exception {
+        when(userService.updateUser(eq(99L), any(User.class)))
+                .thenThrow(new IllegalArgumentException("User not found with id: 99"));
+
+        mockMvc.perform(put("/api/users/99")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(testUser)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getUserById_WhenInvalidId_ShouldReturnBadRequest() throws Exception {
+        mockMvc.perform(get("/api/users/abc"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void deleteUser_WhenNotFound_ShouldReturnNotFound() throws Exception {
+        doThrow(new IllegalArgumentException("User not found")).when(userService).deleteUser(99L);
+
+        mockMvc.perform(delete("/api/users/99"))
+                .andExpect(status().isNotFound());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ExpenseController tests including bad request handling
- cover CategoryController success paths and invalid type cases
- test IncomeProjectionController including validation and calculation
- add UserController tests for typical flows and bad IDs

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.5.3'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894b33933fc832e8ba35d36735426b6