### PR TITLE
Add expense request DTO with validation and error handling

### DIFF
--- a/src/main/java/com/aurfebre/household/api/ExpenseController.java
+++ b/src/main/java/com/aurfebre/household/api/ExpenseController.java
@@ -1,7 +1,9 @@
 package com.aurfebre.household.api;
 
 import com.aurfebre.household.domain.Expense;
+import com.aurfebre.household.dto.ExpenseRequest;
 import com.aurfebre.household.service.ExpenseService;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,7 +26,7 @@ public class ExpenseController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Expense createExpense(@RequestBody Expense expense) {
-        return expenseService.createExpense(expense);
+    public Expense createExpense(@Valid @RequestBody ExpenseRequest expenseRequest) {
+        return expenseService.createExpense(expenseRequest);
     }
 }

--- a/src/main/java/com/aurfebre/household/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/aurfebre/household/api/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.aurfebre.household.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public Map<String, String> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
+        }
+        return errors;
+    }
+}

--- a/src/main/java/com/aurfebre/household/dto/ExpenseRequest.java
+++ b/src/main/java/com/aurfebre/household/dto/ExpenseRequest.java
@@ -1,0 +1,26 @@
+package com.aurfebre.household.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExpenseRequest {
+
+    @NotBlank(message = "Description is required")
+    private String description;
+
+    @NotNull(message = "Amount is required")
+    @Positive(message = "Amount must be positive")
+    private Integer amount;
+
+    @NotBlank(message = "Category is required")
+    private String category;
+}

--- a/src/main/java/com/aurfebre/household/service/ExpenseService.java
+++ b/src/main/java/com/aurfebre/household/service/ExpenseService.java
@@ -1,6 +1,7 @@
 package com.aurfebre.household.service;
 
 import com.aurfebre.household.domain.Expense;
+import com.aurfebre.household.dto.ExpenseRequest;
 import com.aurfebre.household.repository.ExpenseRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +23,12 @@ public class ExpenseService {
         return expenseRepository.findAll();
     }
 
-    public Expense createExpense(Expense expense) {
+    public Expense createExpense(ExpenseRequest expenseRequest) {
+        Expense expense = new Expense(
+                expenseRequest.getDescription(),
+                expenseRequest.getAmount(),
+                expenseRequest.getCategory()
+        );
         return expenseRepository.save(expense);
     }
 }


### PR DESCRIPTION
## Summary
- add `ExpenseRequest` DTO with bean validation constraints
- accept validated `ExpenseRequest` in `ExpenseController` and map to entity via service
- provide `GlobalExceptionHandler` to return validation errors

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.5.3'] was not found in any of the following sources: Gradle Core Plugins, Included Builds, Plugin Repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68975873b080832e9556906c3e095012